### PR TITLE
1.8.0 (#13)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,16 @@
+project('spdlog', 'cpp', version : '1.8.0', license: 'MIT',
+        default_options : ['cpp_std=c++11'])
+
+inc = include_directories('include')
+
+thread_dep = dependency('threads')
+
+if get_option('tests')
+	subdir('tests')
+endif
+if get_option('compile_library')
+    subdir('src')
+    spdlog_dep = declare_dependency(include_directories : inc, dependencies : thread_dep, link_with : spdlog_lib)
+else 
+    spdlog_dep = declare_dependency(include_directories : inc, dependencies : thread_dep)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('tests', type: 'boolean', value: false, description: 'Build the unit tests')
+
+option('compile_library', type: 'boolean', value: false, description: 'Builds a static/shared lib for faster compile times*')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,11 @@
+src = [
+    'spdlog.cpp',
+    'stdout_sinks.cpp',
+    'color_sinks.cpp',
+    'file_sinks.cpp',
+    'async.cpp',
+    'cfg.cpp',
+    'fmt.cpp'
+]
+
+spdlog_lib = library('spdlog',src,include_directories : inc,dependencies : thread_dep, cpp_args : '-DSPDLOG_COMPILED_LIB')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,25 @@
+test_src = [
+    'test_file_helper.cpp',
+    'test_file_logging.cpp',
+    'test_daily_logger.cpp',
+    'test_misc.cpp',
+    'test_eventlog.cpp',
+    'test_pattern_formatter.cpp',
+    'test_async.cpp',
+    'test_registry.cpp',
+    'test_macros.cpp',
+    'utils.cpp',
+    'main.cpp',
+    'test_mpmc_q.cpp',
+    'test_dup_filter.cpp',
+    'test_fmt_helper.cpp',
+    'test_stdout_api.cpp',
+    'test_backtrace.cpp',
+    'test_create_dir.cpp',
+    'test_cfg.cpp',
+    'test_time_point.cpp',
+    'test_stopwatch.cpp'
+]
+
+tests_exe = executable('tests_exe', test_src, include_directories : inc, dependencies : thread_dep)
+test('tests', tests_exe)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = spdlog-1.8.0
+
+source_url = https://github.com/gabime/spdlog/archive/v1.8.0.tar.gz
+source_filename = v1.8.0.tar.gz
+source_hash = 1e68e9b40cf63bb022a4b18cdc1c9d88eb5d97e4fd64fa981950a9cacf57a4bf


### PR DESCRIPTION
* 1.3.1 (#11)

* 1.1.0 (#10)

* Update to 0.17.0

* Add an option to disable building the tests

* Update to 1.1.0

* 1.3.1

* Update to 1.3.1

* updated to 1.8.0 added the ability to compile and link as library
instead of just header only also updated tests

Signed-off-by: XPXPv2 <49757854+XPXPv2@users.noreply.github.com>

Co-authored-by: xiannox <41336647+xiannox@users.noreply.github.com>